### PR TITLE
sync.EtcdUpdater

### DIFF
--- a/sync/etcd_updater.go
+++ b/sync/etcd_updater.go
@@ -1,0 +1,27 @@
+package sync
+
+import (
+	"context"
+
+	"github.com/coreos/etcd/clientv3"
+)
+
+type EtcdUpdater struct {
+	clientv3.KV
+}
+
+// Run will update the etcd key with the given value, but only if the value in etcd is
+// different from our desired update. This avoids causing watchers that are subscribed to
+// changes on this key triggering for multiple PUTs of the same value.
+func (e EtcdUpdater) Run(key, value string) error {
+	txn := e.KV.Txn(context.Background()).
+		If(
+			clientv3.Compare(clientv3.Value(key), "=", value),
+		).
+		Else(
+			clientv3.OpPut(key, value),
+		)
+
+	_, err := txn.Commit()
+	return err
+}

--- a/sync/etcd_updater_test.go
+++ b/sync/etcd_updater_test.go
@@ -1,0 +1,90 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/coreos/etcd/clientv3"
+	"github.com/gocardless/pgsql-cluster-manager/testHelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var seededRandom = rand.New(rand.NewSource(time.Now().UnixNano()))
+var charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// generateKey will create a key that can be used in each of our etcd tests, ensuring we
+// test against different keys for each test even if re-using the same etcd instance.
+func generateKey() string {
+	keyBytes := make([]byte, 20)
+	for idx := range keyBytes {
+		keyBytes[idx] = charset[seededRandom.Intn(len(charset))]
+	}
+
+	return fmt.Sprintf("/%s", keyBytes)
+}
+
+func TestEtcdUpdater(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	etcd := testHelpers.StartEtcd(t, ctx)
+	updater := EtcdUpdater{etcd}
+
+	put := func(key, value string) *clientv3.PutResponse {
+		resp, err := etcd.Put(context.Background(), key, value)
+		require.Nil(t, err)
+
+		return resp
+	}
+
+	get := func(key string) *clientv3.GetResponse {
+		resp, err := etcd.Get(context.Background(), key)
+		require.Nil(t, err)
+
+		return resp
+	}
+
+	testCases := []struct {
+		name         string
+		initialValue string
+		runValue     string
+		revisionDiff int
+	}{
+		{
+			"when etcd has different value, updates etcd",
+			"value",
+			"new-value",
+			1,
+		},
+		{
+			"when etcd matches value, does not update etcd",
+			"value",
+			"value",
+			0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			key := generateKey()
+
+			put(key, tc.initialValue)
+			originalRevision := get(key).Kvs[0].ModRevision
+
+			err := updater.Run(key, tc.runValue)
+			keyAfterHandler := get(key).Kvs[0]
+
+			// In all cases, we should find that etcd is updated with the value that the handler
+			// has been run with.
+			afterValue := tc.runValue
+
+			assert.Nil(t, err)
+			assert.EqualValues(t, afterValue, keyAfterHandler.Value)
+			assert.EqualValues(t, tc.revisionDiff, keyAfterHandler.ModRevision-originalRevision)
+		})
+	}
+}


### PR DESCRIPTION
https://gocardless.myjetbrains.com/youtrack/issue/PT-495

Idempotent etcd value updating, by transactionally updating a value in
etcd only if it does not already match our desired value. We will need
this for pushing pacemaker state to etcd without continually triggering
watchers on those etcd values.