### PR TITLE
Contextify pacemaker api

### DIFF
--- a/command/supervise.go
+++ b/command/supervise.go
@@ -150,7 +150,7 @@ func superviseMigrationCommandFunc(cmd *cobra.Command, args []string) {
 	defer cancel()
 
 	bouncer := PGBouncerOrExit()
-	cib := pacemaker.NewCib()
+	crm := pacemaker.NewPacemaker()
 	bindAddr := viper.GetString("bind-address")
 
 	HandleQuitSignal("cleaning context and exiting...", cancel)
@@ -164,7 +164,7 @@ func superviseMigrationCommandFunc(cmd *cobra.Command, args []string) {
 	server := migration.NewServer(
 		migration.WithServerLogger(logger),
 		migration.WithPGBouncer(bouncer),
-		migration.WithCib(cib),
+		migration.WithPacemaker(crm),
 	)
 
 	grpcServer := grpc.NewServer()

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -28,7 +28,7 @@ func TestIntegration(t *testing.T) {
 	client := cluster.EtcdClient(t)
 
 	outputFile := func(path string) {
-		contents, err := cluster.Executor().CombinedOutput("cat", path)
+		contents, err := cluster.Executor().CombinedOutput(ctx, "cat", path)
 
 		if err == nil {
 			fmt.Printf("$ cat %s\n\n%s\n\n", path, string(contents))
@@ -104,6 +104,7 @@ func TestIntegration(t *testing.T) {
 
 		fmt.Println("running migrate using api...")
 		output, err := cluster.Executor().CombinedOutput(
+			ctx,
 			"pgsql-cluster-manager", "migrate",
 			"--log-level", "debug",
 			"--etcd-namespace", "/postgres",
@@ -130,7 +131,7 @@ func TestIntegration(t *testing.T) {
 				dumpLogs()
 				require.Fail(t, "timed out waiting for node to become master")
 			default:
-				if master, _, _ := cluster.Roles(); master == node {
+				if master, _, _ := cluster.Roles(ctx); master == node {
 					return
 				}
 
@@ -161,7 +162,7 @@ func TestIntegration(t *testing.T) {
 		}
 	}
 
-	master, sync, async := cluster.Roles()
+	master, sync, async := cluster.Roles(ctx)
 
 	conn := connectTo(async)
 	connectedAddr := inetServerAddr(conn)


### PR DESCRIPTION
https://gocardless.myjetbrains.com/youtrack/issue/PT-618

Previously we had the executor configure a set timeout, but this is quite inflexible and doesn't benefit from context chaining where the parent context is cancelled and resources are cleaned up in the dependents.

This change also modifies the terminology so that we don't call the interface around pacemaker a `cib`, instead providing a general `Pacemaker` API. This gets slightly hairy with naming as the word `pacemaker` is taken by the module, but we get away with this by terming the `Pacemaker` instance a `crm` (which is more appropriate than `cib` used to be).