### PR TITLE
Less brittle cibadmin query command

### DIFF
--- a/docker/postgres-member/resource_agents/pgsql
+++ b/docker/postgres-member/resource_agents/pgsql
@@ -1280,8 +1280,8 @@ user_recovery_conf() {
 #
 get_master_id() {
   cibadmin --query \
-    --xpath "//node/instance_attributes/nvpair[@value='LATEST']/../.." | \
-    perl -wnl -e '/<node.* id="(\d+)"/ and print $1'
+    --xpath "//node/instance_attributes/nvpair[@value='LATEST']/../.." --node-path | \
+    perl -wnl -e "/\@id='(\d+)'/ and print \$1"
 }
 
 get_master_ip() {


### PR DESCRIPTION
Have cibadmin produce output that is safer to parse than standard XML.