### PR TITLE
Log when etcd value isn't present

### DIFF
--- a/etcd/subscriber.go
+++ b/etcd/subscriber.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/mvcc/mvccpb"
-	"github.com/Sirupsen/logrus"
 	"golang.org/x/net/context"
 )
 
@@ -125,6 +125,10 @@ func (s *subscriber) bootHandlers(ctx context.Context) {
 
 		if err != nil {
 			s.logger.WithField("key", key).WithError(err).Errorf("etcd get failed")
+		}
+
+		if len(getResp.Kvs) == 0 {
+			s.logger.WithField("key", key).Warn("etcd key had no initial value (is supervise cluster running?)")
 		}
 
 		if len(getResp.Kvs) == 1 {


### PR DESCRIPTION
If we can't find a value in etcd when we initially boot the handlers
then we should log that this is so. Otherwise it's easy to misconfigure
the namespace and think that nothing is happening.