### PR TITLE
Support loading config from environment variables

### DIFF
--- a/command/commands.go
+++ b/command/commands.go
@@ -3,6 +3,7 @@ package command
 import (
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -30,6 +31,12 @@ var (
 )
 
 func init() {
+	// Configure viper so that command-line flags are used as a priority, followed by
+	// environment variables, followed by the supplied defaults
+	viper.AutomaticEnv()
+	viper.SetEnvPrefix("pgsql")
+	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+
 	flags := PgsqlCommand.PersistentFlags()
 
 	// We always need an etcd connection, so these flags are for all commands


### PR DESCRIPTION
Allow users to supply configuration through environment variables. This
is particularly useful for secret material, such as the PgBouncer
password.

```
$ PGSQL_ETCD_NAMESPACE=bazinga ./pgsql-cluster-manager show-config | grep bazinga
etcd-namespace = "bazinga"
```