### PR TITLE
Bump pgbouncer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # pgsql-cluster-manager and also running integration test environments.
 FROM ubuntu:trusty
 
-ENV POSTGRESQL_VERSION=9.4 PGBOUNCER_VERSION=1.8.1-*
+ENV POSTGRESQL_VERSION=9.4 PGBOUNCER_VERSION=1.9.0-*
 RUN set -x \
     && apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
1.8.1 is no longer available for Ubuntu 14.04 in the PPA, since the
release of 1.9.0.