### PR TITLE
pgbouncer.Disable, CurrentConnections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,10 @@ RUN set -x \
         software-properties-common \
         build-essential \
         curl \
-        ruby-dev \
         wget \
         docker.io \
     && wget https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb \
     && dpkg -i dumb-init_*.deb && rm dumb-init_*.deb \
-    && gem install bundler \
     && add-apt-repository ppa:gophers/archive \
     && echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main\ndeb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg 9.4" > /etc/apt/sources.list.d/pgdg.list \
       && curl --silent -L https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \


### PR DESCRIPTION
Add functionality to the pgbouncer package that can be used to perform
graceful shutdown of PgBouncer by first disabling new client
connections, then exposing information on the number of currently
connected clients.

We add tests to verify the behaviour we want: disable should only affect
new connections, and our existing connections continue unaffected.